### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Elements/ElementSponsor.php
+++ b/src/Elements/ElementSponsor.php
@@ -28,12 +28,12 @@ class ElementSponsor extends BaseElement
     /**
      * @var string
      */
-    private static $singular_name = 'Sponsors Element';
+    private static $singular_name = 'Sponsors';
 
     /**
      * @var string
      */
-    private static $plural_name = 'Sponsors Elements';
+    private static $plural_name = 'Sponsors Blocks';
 
     /**
      * @var string
@@ -109,14 +109,6 @@ class ElementSponsor extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Sponsors');
     }
 
     /**


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementSponsor`
- Updated `$singular_name` from `'Sponsors Element'` to `'Sponsors'`
- Updated `$plural_name` from `'Sponsors Elements'` to `'Sponsors Blocks'`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #31

Related: dynamic/silverstripe-essentials-tools#68