### PR TITLE
feat: Silverstripe 6 compatibility (5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Sponsors element for the [SilverStripe Elemental](https://github.com/dnadesign/s
 
 ## Requirements
 
-* dnadesign/silverstripe-elemental ^5
-* dynamic/silverstripe-elemental-baseobject ^5
+* dnadesign/silverstripe-elemental ^6
+* dynamic/silverstripe-elemental-baseobject ^6
 * symbiote/silverstripe-gridfieldextensions ^4
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -1,42 +1,48 @@
 {
-  "name": "dynamic/silverstripe-elemental-sponsors",
-  "description": "Display a list of sponsor logos with links.",
-  "license": "BSD-3-Clause",
-  "type": "silverstripe-vendormodule",
-  "keywords": [
-    "silverstripe",
-    "sponsors",
-    "elemental"
-  ],
-  "authors": [
-    {
-      "name": "Dynamic",
-      "email": "dev@dynamicagency.com",
-      "homepage": "https://www.dynamicagency.com"
-    }
-  ],
-  "require": {
-    "dnadesign/silverstripe-elemental": "^5",
-    "dynamic/silverstripe-elemental-baseobject": "^5",
-    "symbiote/silverstripe-gridfieldextensions": "^4"
-  },
-  "require-dev": {
-    "silverstripe/recipe-testing": "^3"
-  },
-  "minimum-stability": "dev",
-  "prefer-stable": true,
-  "autoload": {
-    "psr-4": {
-      "Dynamic\\Elements\\Sponsors\\": "src/",
-      "Dynamic\\Elements\\Sponsors\\Test\\": "tests/"
-    }
-  },
-  "config": {
-    "allow-plugins": {
-      "composer/installers": true,
-      "silverstripe/recipe-plugin": true,
-      "silverstripe/vendor-plugin": true
+    "name": "dynamic/silverstripe-elemental-sponsors",
+    "description": "Display a list of sponsor logos with links.",
+    "license": "BSD-3-Clause",
+    "type": "silverstripe-vendormodule",
+    "keywords": [
+        "silverstripe",
+        "sponsors",
+        "elemental"
+    ],
+    "authors": [
+        {
+            "name": "Dynamic",
+            "email": "dev@dynamicagency.com",
+            "homepage": "https://www.dynamicagency.com"
+        }
+    ],
+    "require": {
+        "dnadesign/silverstripe-elemental": "^6",
+        "dynamic/silverstripe-elemental-baseobject": "^6",
+        "symbiote/silverstripe-gridfieldextensions": "^4",
+        "silverstripe/vendor-plugin": "^3"
     },
-    "process-timeout": 600
-  }
+    "require-dev": {
+        "silverstripe/recipe-testing": "^4"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "Dynamic\\Elements\\Sponsors\\": "src/",
+            "Dynamic\\Elements\\Sponsors\\Test\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/recipe-plugin": true,
+            "silverstripe/vendor-plugin": true
+        },
+        "process-timeout": 600
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.x-dev"
+        }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true">
     <testsuites>
         <testsuite name="elemental-sponsors">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 5 support. Major version 5.0 requiring Silverstripe 6 only.

## Changes

- **composer.json**: `elemental ^6`, `baseobject ^6`, `vendor-plugin ^3`
- **require-dev**: `recipe-testing ^4`
- **branch-alias**: `5.x-dev`
- **phpunit.xml.dist**: Update to PHPUnit 11 format
- **README.md**: Update requirements to SS6

## Version History

| Version | Silverstripe |
|---------|-------------|
| 5.x     | ^6          |
| 4.x     | ^5          |
| 3.x     | ^4          |
