### PR TITLE
fix: SS6 dependency constraint — gridfieldextensions ^5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "dnadesign/silverstripe-elemental": "^6",
         "dynamic/silverstripe-elemental-baseobject": "^6",
-        "symbiote/silverstripe-gridfieldextensions": "^4",
+        "symbiote/silverstripe-gridfieldextensions": "^5",
         "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {


### PR DESCRIPTION
## Bug

`gridfieldextensions ^4` requires `vendor-plugin ^2`, which conflicts with SS6's `vendor-plugin ^3`. This prevents `composer update` from resolving.

## Fix
- `symbiote/silverstripe-gridfieldextensions`: `^4` → `^5` (5.2.0 is SS6-compatible)