### PR TITLE
fix(#38): remove getType() override + port $owns to SS6 branch 5

### DIFF
--- a/src/Elements/ElementSponsor.php
+++ b/src/Elements/ElementSponsor.php
@@ -28,12 +28,12 @@ class ElementSponsor extends BaseElement
     /**
      * @var string
      */
-    private static $singular_name = 'Sponsors Element';
+    private static $singular_name = 'Sponsors';
 
     /**
      * @var string
      */
-    private static $plural_name = 'Sponsors Elements';
+    private static $plural_name = 'Sponsors Blocks';
 
     /**
      * @var string
@@ -63,6 +63,13 @@ class ElementSponsor extends BaseElement
             // would be sort but issues arise when parent and child both have the same sort field names.
             'SponsorSort' => 'Int',
         ],
+    ];
+
+    /**
+     * @var array
+     */
+    private static $owns = [
+        'Sponsors',
     ];
 
     /**
@@ -102,14 +109,6 @@ class ElementSponsor extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__.'.BlockType', 'Sponsors');
     }
 
     /**


### PR DESCRIPTION
Closes #38.

Ports two branch-4 changes the stale-forked SS6 branch `5` missed:
- **#32** — remove the `getType()` override (allows extensibility); rename `$singular_name` → 'Sponsors', `$plural_name` → 'Sponsors Blocks'.
- **#27** — add `$owns = ['Sponsors']` so related Sponsors publish with the element.

## Verification
- `ddev sake dev/build flush=1` → exit 0
- php -l + phpcs (PSR12) clean

Identified by the SS6 sync-gap audit (2026-06-10).