### PR TITLE
docs: standardize README, centralize governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing
-
-Contributions are welcome! Create an issue, explaining a bug or proposal. Submit pull requests if you feel brave.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# SilverStripe Elemental Sponsors Block
+# Silverstripe Elemental Sponsors
 
 Sponsors element for the [SilverStripe Elemental](https://github.com/dnadesign/silverstripe-elemental) module
 
-[![CI](https://github.com/dynamic/silverstripe-elemental-sponsors/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-elemental-sponsors/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/dynamic/silverstripe-elemental-sponsors/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-elemental-sponsors)
+[![CI](https://github.com/dynamic/silverstripe-elemental-sponsors/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-elemental-sponsors/actions/workflows/ci.yml) [![Sponsors](https://img.shields.io/badge/GitHub-Sponsors-ff69b4?logo=github)](https://github.com/sponsors/dynamic)
 
 [![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-elemental-sponsors/v/stable)](https://packagist.org/packages/dynamic/silverstripe-elemental-sponsors)
 [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-elemental-sponsors/downloads)](https://packagist.org/packages/dynamic/silverstripe-elemental-sponsors)
@@ -14,15 +13,12 @@ Sponsors element for the [SilverStripe Elemental](https://github.com/dnadesign/s
 
 * dnadesign/silverstripe-elemental ^6
 * dynamic/silverstripe-elemental-baseobject ^6
-* symbiote/silverstripe-gridfieldextensions ^4
+* silverstripe/vendor-plugin ^3
+* symbiote/silverstripe-gridfieldextensions ^5
 
 ## Installation
 
 `composer require dynamic/silverstripe-elemental-sponsors`
-
-## License
-
-See [License](LICENSE.md)
 
 ## Upgrading from version 4
 
@@ -30,7 +26,7 @@ This module drops `gorriecoe/silverstripe-linkfield` usage in favor of `silverst
 
 ## Usage
 
-A block that allows you to display multiple sponsors. Each sponsor can have a Title, Link, Image and Description. By default, the layout only shows the Image or Title with a link wrapped around it (if it's added).
+A block that allows you to display multiple sponsors. Each sponsor can have a Title, Link, Image and Description. By default, the layout only shows the Image or Title with a link wrapped around it (if it is added).
 
 An example enhancement would be to hookup a carousel to scroll through the sponsors instead of having multiple rows.
 
@@ -48,32 +44,34 @@ An example enhancement would be to hookup a carousel to scroll through the spons
 #### CMS - Sponsors Element - Sponsor Add/Edit
 ![CMS - Sponsors Element Main Tab](./docs/en/_images/sponsors-block-cms-sponsor.jpg)
 
-
 ## Getting more elements
 
 See [Elemental modules by Dynamic](https://github.com/orgs/dynamic/repositories?q=elemental&type=all&language=&sort=)
 
 ## Configuration
 
-See [SilverStripe Elemental Configuration](https://github.com/silverstripe/silverstripe-elemental#configuration)
+See [SilverStripe Elemental Configuration](https://github.com/dnadesign/silverstripe-elemental#configuration)
 
 ## Maintainers
 
-*  [Dynamic](https://www.dynamicagency.com) (<dev@dynamicagency.com>)
+ *  [Dynamic](https://www.dynamicagency.com) (<dev@dynamicagency.com>)
 
 ## Bugtracker
-Bugs are tracked in the issues section of this repository. Before submitting an issue please read over
-existing issues to ensure yours is unique.
+
+Bugs are tracked in the issues section of this repository. Before submitting an issue please read over existing issues to ensure yours is unique.
 
 If the issue does look like a new bug:
 
-- Create a new issue
-- Describe the steps required to reproduce your issue, and the expected outcome. Unit tests, screenshots
-  and screencasts can help here.
-- Describe your environment as detailed as possible: SilverStripe version, Browser, PHP version,
-  Operating System, any installed SilverStripe modules.
+ - Create a new issue
+ - Describe the steps required to reproduce your issue, and the expected outcome. Unit tests, screenshots and screencasts can help here.
+ - Describe your environment as detailed as possible: SilverStripe version, Browser, PHP version, Operating System, any installed SilverStripe modules.
 
 Please report security issues to the module maintainers directly. Please don't file security issues in the bugtracker.
 
 ## Development and contribution
+
 If you would like to make contributions to the module please ensure you raise a pull request and discuss with the module maintainers.
+
+## License
+
+See [License](LICENSE.md)


### PR DESCRIPTION
Standardizes README to canonical template, removes per-repo governance files now centralized in dynamic/.github. Part of the Essentials suite-wide documentation standardization.

- Remove deprecated codecov branch/master badge; add GitHub Sponsors badge
- Fix symbiote/silverstripe-gridfieldextensions constraint from ^4 to ^5 (matches composer.json)
- Add silverstripe/vendor-plugin ^3 to Requirements
- Reorder sections to canonical template order (License moved to end)
- Remove redundant CONTRIBUTING.md (org default in dynamic/.github)